### PR TITLE
Add OAuth2 support for IMAP polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Navigate to the folder on your server where you want to run the script.
 3. In your MySQL database, create the tables "emails" and "files" by importing the file:
 * mysql-structure.sql
 
-4. Open the file config.php and add your MySQL and POP credentials.
+4. Run `composer install` to install required dependencies. The mini-app now
+   relies on `stevenmaguire/oauth2-microsoft` for OAuth2 support.
+
+5. Open the file config.php and add your MySQL details and OAuth2 credentials.
 
 # Pipe vs Fetch
 You can either pipe an email address to the script to process each email as it arrives, or you can fetch emails one-by-one from a mailbox using a cron job (emails are deleted as they're processed.) We recommend using the fetch method.

--- a/application.php
+++ b/application.php
@@ -4,6 +4,7 @@
 require_once("config.php");
 require_once("class.php");
 require_once("mimeDecode.php");
+require_once(__DIR__ . '/vendor/autoload.php');
 
 set_time_limit(600);
 ini_set('max_execution_time',600);
@@ -29,8 +30,22 @@ if ($grab_type == "pipe") {
 
 /* Fetch */
 if ($grab_type == "fetch") {
- 
-  $inbox = @imap_open("{".$imap_host.$imap_flags."}INBOX",$imap_user,$imap_pass);
+
+  // Obtain OAuth2 access token using refresh token
+  $provider = new Stevenmaguire\OAuth2\Client\Provider\Microsoft([
+    'clientId'     => $oauth_client_id,
+    'clientSecret' => $oauth_client_secret,
+    'redirectUri'  => '',
+    'tenant'       => $oauth_tenant,
+  ]);
+
+  $token = $provider->getAccessToken('refresh_token', [
+    'refresh_token' => $oauth_refresh_token,
+  ]);
+
+  $accessToken = $token->getToken();
+
+  $inbox = @imap_open("{".$imap_host.$imap_flags."}INBOX", $imap_user, $accessToken);
  
   if ($inbox) {
     $emails = imap_search($inbox,"ALL");

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "stevenmaguire/oauth2-microsoft": "^3.1"
+  }
+}

--- a/config.php
+++ b/config.php
@@ -5,10 +5,15 @@ $mysql_user = ""; // MySQL username
 $mysql_pass = ""; // MySQL password
 $mysql_db   = ""; // MySQL database name
 
-$imap_host  = "outlook.office365.com"; // IMAP host address
-$imap_flags = "/pop3/novalidate-cert"; // IMAP Flags
-$imap_user  = "coordinator@first-base.co.uk"; // IMAP username
-$imap_pass  = "jfgymghzpnqplwxv"; // IMAP password
+$imap_host  = "outlook.office365.com:993"; // IMAP host address
+$imap_flags = "/imap/ssl/auth=xoauth2"; // IMAP Flags for OAuth2
+$imap_user  = ""; // IMAP username
+
+// OAuth2 settings for Microsoft
+$oauth_client_id     = "";
+$oauth_client_secret = "";
+$oauth_tenant        = "common"; // or your tenant ID
+$oauth_refresh_token = ""; // Refresh token used to obtain access tokens
 
 $file_store = "files"; // Folder where file attachments are saved
 $grab_type  = "fetch"; // Type of mail grab - "pipe" or "fetch"


### PR DESCRIPTION
## Summary
- add composer setup for oauth2 client
- explain composer install in README
- configure IMAP OAuth2 settings
- fetch an access token using stevenmaguire/oauth2-microsoft before opening IMAP

## Testing
- `php -l application.php`
- `php -l config.php`


------
https://chatgpt.com/codex/tasks/task_e_6851475cd8288322966896747a8ad3c3